### PR TITLE
Enable loading of YAML configuration files

### DIFF
--- a/Notes.kt
+++ b/Notes.kt
@@ -1,8 +1,8 @@
 #!/usr/bin/env kscript
 
 //COMPILER_OPTS -jvm-target 1.8
-@file:DependsOn("com.google.code.gson:gson:2.8.6")
 @file:DependsOn("com.sksamuel.hoplite:hoplite-core:1.2.0")
+@file:DependsOn("com.sksamuel.hoplite:hoplite-json:1.2.0")
 @file:Include("src/main/kotlin/com/micbakos/notes/ArgumentsReader.kt")
 @file:Include("src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt")
 @file:Include("src/main/kotlin/com/micbakos/notes/GitLogger.kt")

--- a/Notes.kt
+++ b/Notes.kt
@@ -1,6 +1,7 @@
 #!/usr/bin/env kscript
 
 @file:DependsOn("com.google.code.gson:gson:2.8.6")
+@file:DependsOn("com.sksamuel.hoplite:hoplite-core:1.2.0")
 @file:Include("src/main/kotlin/com/micbakos/notes/ArgumentsReader.kt")
 @file:Include("src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt")
 @file:Include("src/main/kotlin/com/micbakos/notes/GitLogger.kt")

--- a/Notes.kt
+++ b/Notes.kt
@@ -1,5 +1,6 @@
 #!/usr/bin/env kscript
 
+//COMPILER_OPTS -jvm-target 1.8
 @file:DependsOn("com.google.code.gson:gson:2.8.6")
 @file:DependsOn("com.sksamuel.hoplite:hoplite-core:1.2.0")
 @file:Include("src/main/kotlin/com/micbakos/notes/ArgumentsReader.kt")

--- a/Notes.kt
+++ b/Notes.kt
@@ -3,6 +3,7 @@
 //COMPILER_OPTS -jvm-target 1.8
 @file:DependsOn("com.sksamuel.hoplite:hoplite-core:1.2.0")
 @file:DependsOn("com.sksamuel.hoplite:hoplite-json:1.2.0")
+@file:DependsOn("com.sksamuel.hoplite:hoplite-yaml:1.2.0")
 @file:Include("src/main/kotlin/com/micbakos/notes/ArgumentsReader.kt")
 @file:Include("src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt")
 @file:Include("src/main/kotlin/com/micbakos/notes/GitLogger.kt")

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ This goal of this script is to laverage the infrastracture of the company and th
 
 ## Installation
 * Clone the project
+* Use JDK 8 (this is due to issues with dependency resolution of kscript)
 * Install kscript. Follow the steps described [here](https://github.com/holgerbrandl/kscript#installation).
 
-## Dunamic configuration
+## Dynamic configuration
 In order for the script to run dynamically, the user needs to create a configuration file (in Json format) and place it anywhere inside their project. **The file needs to be named `notesConfig.json`**
 
 The configuration file needs to define the following attributes:
@@ -28,6 +29,35 @@ The configuration file needs to define the following attributes:
   - `url`: The replacement url of each issue in order to transform it to a link.
 
 ### Example of a configuration file:
+
+#### Yaml
+```yaml
+
+---
+variants:
+- name: passenger
+  categories:
+  - title: Product
+    regex: taxibeat\/(passenger|all)\/(feature)\/(?!infra).+\/.+
+  - title: Infra
+    regex: taxibeat\/(passenger|all)\/(feature|chapter)\/infra\/.+
+  - title: Bugs
+    regex: taxibeat\/(passenger|all)\/(bugfix|hotfix)\/.+
+- name: driver
+  categories:
+  - title: Product
+    regex: taxibeat\/(driver|all)\/(feature)\/(?!infra).+\/.+
+  - title: Infra
+    regex: taxibeat\/(driver|all)\/(feature|chapter)\/infra\/.+
+  - title: Bugs
+    regex: taxibeat\/(driver|all)\/(bugfix|hotfix)\/.+
+links:
+- url: https://jira.taxibeat.com/browse/$1
+  regex: "\\[(\\D+-\\d+)\\]"
+
+```
+
+#### JSON
 ```
 {
   "variants": [

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This goal of this script is to laverage the infrastracture of the company and th
 * Install kscript. Follow the steps described [here](https://github.com/holgerbrandl/kscript#installation).
 
 ## Dynamic configuration
-In order for the script to run dynamically, the user needs to create a configuration file (in Json format) and place it anywhere inside their project. **The file needs to be named `notesConfig.json`**
+In order for the script to run dynamically, the user needs to create a configuration file (in Json or Yaml format) and place it anywhere inside their project. **The file needs to be named `notesConfig.[json|yaml|yml]`**
 
 The configuration file needs to define the following attributes:
 - `variants`: Each variant is a representation of a project that outputs release notes. Some repositories may consist of more than one project.

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-script-runtime"
     implementation "com.github.holgerbrandl:kscript-annotations:1.2"
     implementation "com.google.code.gson:gson:2.8.6"
+    implementation "com.sksamuel.hoplite:hoplite-core:1.2.0"
 }
 
 sourceSets.main.java.srcDirs 'src'

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     implementation "com.github.holgerbrandl:kscript-annotations:1.2"
     implementation "com.google.code.gson:gson:2.8.6"
     implementation "com.sksamuel.hoplite:hoplite-core:1.2.0"
+    implementation "com.sksamuel.hoplite:hoplite-yaml:1.2.0"
+    implementation "com.sksamuel.hoplite:hoplite-json:1.2.0"
 }
 
 sourceSets.main.java.srcDirs 'src'

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,12 @@ repositories {
     jcenter()
 }
 
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = 1.8
+    }
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     implementation "org.jetbrains.kotlin:kotlin-script-runtime"

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,12 @@ repositories {
     jcenter()
 }
 
-compileKotlin {
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
     kotlinOptions {
-        jvmTarget = 1.8
+        jvmTarget = "1.8"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     implementation "org.jetbrains.kotlin:kotlin-script-runtime"
     implementation "com.github.holgerbrandl:kscript-annotations:1.2"
-    implementation "com.google.code.gson:gson:2.8.6"
     implementation "com.sksamuel.hoplite:hoplite-core:1.2.0"
     implementation "com.sksamuel.hoplite:hoplite-yaml:1.2.0"
     implementation "com.sksamuel.hoplite:hoplite-json:1.2.0"

--- a/src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt
+++ b/src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt
@@ -1,7 +1,7 @@
 package com.micbakos.notes
 
-import com.google.gson.Gson
-import com.google.gson.JsonSyntaxException
+import com.sksamuel.hoplite.ConfigException
+import com.sksamuel.hoplite.ConfigLoader
 import java.io.File
 import kotlin.system.exitProcess
 
@@ -20,8 +20,8 @@ fun resolveConfig(arguments: Arguments): Config {
 
 fun File.readConfig(): Config {
     return try {
-        Gson().fromJson(readText(), Config::class.java)
-    } catch (exception: JsonSyntaxException) {
+        ConfigLoader().loadConfigOrThrow<Config>(this.toPath())
+    } catch (exception: ConfigException) {
         System.err.println("Error parsing ${ProjectConfiguration.FILE_NAME}")
         exitProcess(-1)
     }

--- a/src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt
+++ b/src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt
@@ -1,17 +1,16 @@
 package com.micbakos.notes
 
-import com.sksamuel.hoplite.ConfigException
 import com.sksamuel.hoplite.ConfigLoader
 import java.io.File
 import kotlin.system.exitProcess
 
 fun resolveConfig(arguments: Arguments): Config {
     val matches: Array<File>? = File(arguments.directory).listFiles { _, name ->
-        name.endsWith(ProjectConfiguration.FILE_NAME)
+        ProjectConfiguration.VALID_FILE_NAMES.contains(name)
     }
 
     if (matches == null || matches.isEmpty()) {
-        System.err.println("No file named '${ProjectConfiguration.FILE_NAME}' was found inside '${arguments.directory}'")
+        System.err.println("No file named '${ProjectConfiguration.VALID_FILE_NAMES}' was found inside '${arguments.directory}'")
         exitProcess(-1)
     } else {
         return matches[0].readConfig()
@@ -21,8 +20,9 @@ fun resolveConfig(arguments: Arguments): Config {
 fun File.readConfig(): Config {
     return try {
         ConfigLoader().loadConfigOrThrow<Config>(this.toPath())
-    } catch (exception: ConfigException) {
-        System.err.println("Error parsing ${ProjectConfiguration.FILE_NAME}")
+    } catch (exception: RuntimeException) {
+        System.err.println("Error parsing ${this.name}")
+        exception.printStackTrace()
         exitProcess(-1)
     }
 }

--- a/src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt
+++ b/src/main/kotlin/com/micbakos/notes/EnvironmentConfig.kt
@@ -13,6 +13,7 @@ fun resolveConfig(arguments: Arguments): Config {
         System.err.println("No file named '${ProjectConfiguration.VALID_FILE_NAMES}' was found inside '${arguments.directory}'")
         exitProcess(-1)
     } else {
+        if (matches.size > 1) System.out.println("Found multiple configuration files. Loading ${matches[0].name}")
         return matches[0].readConfig()
     }
 }

--- a/src/main/kotlin/com/micbakos/notes/Models.kt
+++ b/src/main/kotlin/com/micbakos/notes/Models.kt
@@ -6,10 +6,15 @@ package com.micbakos.notes
 class ProjectConfiguration {
 
     companion object {
-        private const val JSON_SUFFIX = "json"
-        private const val YAML_SUFFIX = "yaml"
-        private const val YML_SUFFIX = "yml"
-        const val FILE_NAME = "notesConfig.$JSON_SUFFIX"
+        private const val JSON_SUFFIX = ".json"
+        private const val YAML_SUFFIX = ".yaml"
+        private const val YML_SUFFIX = ".yml"
+        private const val FILE_NAME_PREFIX = "notesConfig"
+        val VALID_FILE_NAMES: List<String> = listOf(
+            FILE_NAME_PREFIX + JSON_SUFFIX,
+            FILE_NAME_PREFIX + YAML_SUFFIX,
+            FILE_NAME_PREFIX + YML_SUFFIX
+        )
         const val PULL_REQUEST_ID_REGEX = "(#\\d+)"
     }
 

--- a/src/main/kotlin/com/micbakos/notes/Models.kt
+++ b/src/main/kotlin/com/micbakos/notes/Models.kt
@@ -6,7 +6,10 @@ package com.micbakos.notes
 class ProjectConfiguration {
 
     companion object {
-        const val FILE_NAME = "notesConfig.json"
+        private const val JSON_SUFFIX = "json"
+        private const val YAML_SUFFIX = "yaml"
+        private const val YML_SUFFIX = "yml"
+        const val FILE_NAME = "notesConfig.$JSON_SUFFIX"
         const val PULL_REQUEST_ID_REGEX = "(#\\d+)"
     }
 

--- a/src/main/kotlin/com/micbakos/notes/Models.kt
+++ b/src/main/kotlin/com/micbakos/notes/Models.kt
@@ -1,7 +1,5 @@
 package com.micbakos.notes
 
-import com.google.gson.annotations.SerializedName
-
 /**
  * Need a class to be able to use a const val, since top level constants are not supported
  */

--- a/src/main/kotlin/com/micbakos/notes/PullRequestResolver.kt
+++ b/src/main/kotlin/com/micbakos/notes/PullRequestResolver.kt
@@ -32,7 +32,7 @@ fun resolve(log: String, config: Config, arguments: Arguments): Map<String, List
 
 private fun ensureVariant(config: Config, arguments: Arguments): Variant {
     return config.variants.find { it.name == arguments.variant } ?: run {
-        System.err.println("Variant named: ${arguments.variant} does not exist in ${ProjectConfiguration.FILE_NAME}")
+        System.err.println("Variant named: ${arguments.variant} does not exist in file loaded.")
         exitProcess(-1)
     }
 }


### PR DESCRIPTION
In this pull request the replacement of Gson with [hoplite](https://github.com/sksamuel/hoplite)
is being added.
Hoplite has the benefit of allowing multiple configuration options.
As such the `json` loading option is still available, so as to not break other people's scripts.

It also contains the following
- Target java bytecode 8 (for enabling Hoplite to function)
- Add instruction in readme to use the JDK 8, to circumvent an issue in kscript itself, where dependencies cannot be resolved properly when using jdk > 8
- No changes were needed in the configuration data model, as it had already been defined in the proper  `data class` format 🎉 

This closes #1. 